### PR TITLE
Add some definitions

### DIFF
--- a/.config/project/default.nix
+++ b/.config/project/default.nix
@@ -10,10 +10,15 @@
   ## development
   programs = {
     direnv.enable = true;
-    # This should default by whether there is a .git file/dir (and whether it’s
-    # a file (worktree) or dir determines other things – like where hooks
-    # are installed.
-    git.enable = true;
+    git = {
+      # This should default by whether there is a .git file/dir (and whether
+      # it’s a file (worktree) or dir determines other things – like where hooks
+      # are installed.
+      enable = true;
+      ignores = [
+        "*.ibc" # compiled Idris files
+      ];
+    };
   };
 
   ## formatting

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /result
 /source
+*.ibc
 /.cache/vale/*
 !/.cache/vale/config/
 /.cache/vale/config/*

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,9 @@
           (pkgs-23_05.idrisPackages.build-idris-package {
             inherit pname src;
 
-            version = "0.1.0";
+            version = "0.2.0";
+
+            idrisDeps = [pkgs-23_05.idrisPackages.comonad];
 
             doCheck = true;
 

--- a/iaia.ipkg
+++ b/iaia.ipkg
@@ -1,7 +1,10 @@
 package iaia
 
+pkgs = comonad
+
 sourcedir = src
 modules = Iaia,
+          Iaia.Applied,
           Iaia.Control,
           Iaia.Data,
           Iaia.Native.Control,

--- a/src/Iaia/Applied.idr
+++ b/src/Iaia/Applied.idr
@@ -1,0 +1,21 @@
+||| The usual data types, but re-expressed in terms of fixed-points.
+module Iaia.Applied
+
+import Iaia
+import Iaia.Control
+import Iaia.Data
+
+%access public export
+%default total
+
+infinity : (Corecursive t Maybe) => t
+infinity = ana Just ()
+
+List : Type -> Type
+List a = Mu (XNor a)
+
+Colist : Type -> Type
+Colist a = Nu (XNor a)
+
+Stream : Type -> Type
+Stream a = Nu (Pair a)

--- a/src/Iaia/Control.idr
+++ b/src/Iaia/Control.idr
@@ -1,5 +1,6 @@
 module Iaia.Control
 
+import Control.Comonad
 import Iaia
 
 %access public export
@@ -24,15 +25,12 @@ DistributiveLaw f g = {a : Type} -> f (g a) -> g (f a)
 ||| `gcata` version?
 interface Steppable t (f : Type -> Type) | t where
   project : Coalgebra f t
-  
+
 interface Costeppable t (f : Type -> Type) | t where
   embed : Algebra f t
-  
+
 interface Recursive t (f : Type -> Type) | t where
   cata : Algebra f a -> t -> a
-  -- ||| Types that have a `Costeppable` `implementation` can simply use `para'`
-  -- ||| here.
-  -- para : (f (t, a) -> a) -> t -> a
 
 interface Corecursive t (f : Type -> Type) | t where
   ana : Coalgebra f a -> a -> t
@@ -59,20 +57,17 @@ gana
   -> t
 gana k ψ = ana (lowerCoalgebra k ψ) . pure
 
--- lowerAlgebra
---   : (Functor f, Comonad w)
---   => DistributiveLaw f w
---   -> GAlgebra w f a
---   -> Algebra f (w a)
--- lowerAlgebra k φ = fmap φ . k . fmap duplicate
+lowerAlgebra
+  : (Functor f, Comonad w)
+  => DistributiveLaw f w
+  -> GAlgebra w f a
+  -> Algebra f (w a)
+lowerAlgebra k φ = map φ . k . map duplicate
 
--- gcata
---   : (Recursive t f, Functor f, Comonad w)
---   => DistributiveLaw f w
---   -> GAlgebra w f a
---   -> t
---   -> a
--- gcata k φ = extract . cata (lowerAlgebra k φ)
+-- ||| Can’t unfold directly over a monad, because it would force the entire
+-- ||| structure, so this enables an effectful stream.
+-- composeCoalgebra : (a -> m (f a)) -> Coalgebra (Compose m f) a
+-- composeCoalgebra = (Compose .)
 
 -- Arrow defined for functions
 infixr 3 ***
@@ -90,6 +85,9 @@ public export (\|/) : (a -> c) -> (b -> c) -> Either a b -> c
 f \|/ g = \a => case a of
                   Left a => f a
                   Right a => g a
+
+zipAlgebras : (Functor f) => Algebra f a -> Algebra f b -> Algebra f (Pair a b)
+zipAlgebras φ φ' = φ . map fst &&& φ' . map snd
 
 distZygo : Functor f => Algebra f a -> DistributiveLaw f (Pair a)
 distZygo φ = φ . map fst &&& map snd

--- a/src/Iaia/Data.idr
+++ b/src/Iaia/Data.idr
@@ -10,13 +10,11 @@ import Iaia.Control
 data Mu : (Type -> Type) -> Type where
   MuF : ({a : Type} -> Algebra f a -> a) -> Mu f
 
-mutual
-  implementation Functor f => Costeppable (Mu f) f where
-    embed fm = MuF (\φ => φ (map (cata φ) fm))
+implementation Functor f => Recursive (Mu f) f where
+  cata φ (MuF f) = f φ
 
-  implementation Functor f => Recursive (Mu f) f where
-    cata φ (MuF f) = f φ
-    -- para = para'
+implementation Functor f => Costeppable (Mu f) f where
+  embed fm = MuF (\φ => φ (map (cata φ) fm))
 
 implementation Functor f => Steppable (Mu f) f where
   project = lambek
@@ -29,12 +27,11 @@ data Nu : (Type -> Type) -> Type where
 implementation Functor f => Steppable (Nu f) f where
   project (NuF f a) = NuF f <$> f a
 
-mutual
-  implementation Functor f => Costeppable (Nu f) f where
-    embed = colambek
+implementation Corecursive (Nu f) f where
+  ana = NuF
 
-  implementation Corecursive (Nu f) f where
-    ana = NuF
+implementation Functor f => Costeppable (Nu f) f where
+  embed = colambek
 
 ||| A type that has either two values or none (isomorphic to `Maybe (a, b)`).
 ||| This is also the pattern functor for list-like structures.

--- a/src/Iaia/Native/Data.idr
+++ b/src/Iaia/Native/Data.idr
@@ -19,7 +19,7 @@ mutual
   boundedFixRec (S n) f = f (BoundedFix n f)
 
 implementation Uninhabited (BoundedFix Z f) where
-  uninhabited (BFx f) impossible 
+  uninhabited (BFx f) impossible
 
 bunfix : BoundedFix (S n) f -> f (BoundedFix n f)
 bunfix = out

--- a/src/Iaia/Zoo.idr
+++ b/src/Iaia/Zoo.idr
@@ -1,10 +1,39 @@
 module Iaia.Zoo
 
+import Control.Comonad
 import Iaia
 import Iaia.Control
 
 %access public export
 %default total
+
+-- __TODO__: This should be in the comonad library
+Comonad (Pair a) where
+  duplicate (b, a) = (b, (b, a))
+  extract (_, a) = a
+
+gcata
+  : (Recursive t f, Functor f, Comonad w)
+  => DistributiveLaw f w
+  -> GAlgebra w f a
+  -> t
+  -> a
+gcata k φ = extract . cata (lowerAlgebra k φ)
+
+zygo
+  : (Recursive t f, Functor f)
+  => Algebra f a
+  -> GAlgebra (Pair a) f b
+  -> t
+  -> b
+zygo φ' = gcata $ distZygo φ'
+
+para
+  : (Costeppable t f, Recursive t f, Functor f)
+  => GAlgebra (Pair t) f a
+  -> t
+  -> a
+para = zygo embed
 
 apo
   : (Corecursive t f, Steppable t f, Functor f)


### PR DESCRIPTION
This library has lagged behind a number of the others, so this moves over some of the existing definitions. This doesn’t affect any existing definitions (even in places where the current naming is out of sync with other libraries), so it’s a compatible change … except that it also adds a dependency on the comonad package.